### PR TITLE
Add 'alternative headers' for data load

### DIFF
--- a/metadata-schema/baseSchema.schema.json
+++ b/metadata-schema/baseSchema.schema.json
@@ -4,12 +4,24 @@
   "properties": {
     "client_side_checksum": {
       "type": "string",
-      "propertyType": "System"
+      "propertyType": "System",
+      "minLength": 64,
+      "maximum": 64,
+      "alternateKeys": [
+        {
+          "tdrDataLoadHeader": "SHA256ClientSideChecksum"
+        }
+      ]
     },
     "file_size": {
       "propertyType": "System",
-      "type": "number",
-      "minimum": 0
+      "type": "integer",
+      "minimum": 0,
+      "alternateKeys": [
+        {
+          "tdrDataLoadHeader": "ClientSideFileSize"
+        }
+      ]
     },
     "UUID": {
       "type": "string",
@@ -27,7 +39,8 @@
       "minLength": 1,
        "alternateKeys": [
         {
-          "tdrFileHeader": "Filepath"
+          "tdrFileHeader": "Filepath",
+          "tdrDataLoadHeader": "ClientSideOriginalFilepath"
         }
       ]
     },
@@ -37,7 +50,8 @@
       "propertyType": "System",
        "alternateKeys": [
         {
-          "tdrFileHeader": "Date last modified"
+          "tdrFileHeader": "Date last modified",
+          "tdrDataLoadHeader": "ClientSideFileLastModifiedDate"
         }
       ]
     },
@@ -84,7 +98,8 @@
       "minLength": 1,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Filename"
+          "tdrFileHeader": "Filename",
+          "tdrDataLoadHeader": "Filename"
         }
       ]
     },
@@ -113,7 +128,8 @@
       "maxLength": 8000,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Alternative description"
+          "tdrFileHeader": "Alternative description",
+          "tdrDataLoadHeader": "DescriptionAlternate"
         }
       ]
     },
@@ -125,7 +141,8 @@
       "propertyType": "Supplied",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Is the description sensitive for the public?"
+          "tdrFileHeader": "Is the description sensitive for the public?",
+          "tdrDataLoadHeader": "DescriptionClosed"
         }
       ]
     },
@@ -138,7 +155,8 @@
       "propertyType": "Supplied",
       "alternateKeys": [
         {
-          "tdrFileHeader": "FOI decision asserted"
+          "tdrFileHeader": "FOI decision asserted",
+          "tdrDataLoadHeader": "FoiExemptionAsserted"
         }
       ],
       "daBeforeToday": "Validates that FOI Exemption Asserted Date is before today's date"
@@ -155,7 +173,8 @@
       },
       "alternateKeys": [
         {
-          "tdrFileHeader": "FOI exemption code"
+          "tdrFileHeader": "FOI exemption code",
+          "tdrDataLoadHeader": "FoiExemptionCode"
         }
       ]
     },
@@ -165,7 +184,8 @@
       "$ref": "classpath:/metadata-schema/definitionsSchema.schema.json#/definitions/closure_types",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Closure status"
+          "tdrFileHeader": "Closure status",
+          "tdrDataLoadHeader": "ClosureType"
         }
       ]
     },
@@ -179,7 +199,8 @@
       "maximum": 150,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Closure Period"
+          "tdrFileHeader": "Closure Period",
+          "tdrDataLoadHeader": "ClosurePeriod"
         }
       ]
     },
@@ -192,7 +213,8 @@
       "propertyType": "Supplied",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Closure Start Date"
+          "tdrFileHeader": "Closure Start Date",
+          "tdrDataLoadHeader": "ClosureStartDate"
         }
       ]
     },
@@ -204,7 +226,8 @@
       "propertyType": "Supplied",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Is the title sensitive for the public?"
+          "tdrFileHeader": "Is the title sensitive for the public?",
+          "tdrDataLoadHeader": "ClosureType"
         }
       ]
     },
@@ -217,7 +240,8 @@
       "maxLength": 8000,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Add alternative title without the file extension"
+          "tdrFileHeader": "Add alternative title without the file extension",
+          "tdrDataLoadHeader": "TitleAlternate"
         }
       ]
     },

--- a/metadata-schema/dataLoadSharePointSchema.schema.json
+++ b/metadata-schema/dataLoadSharePointSchema.schema.json
@@ -7,25 +7,25 @@
         "UUID": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/UUID"
         },
-        "date_last_modified": {
+        "ClientSideFileLastModifiedDate": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/date_last_modified"
         },
-        "client_side_checksum": {
+        "SHA256ClientSideChecksum": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/client_side_checksum"
         },
-        "file_size": {
+        "ClientSideFileSize": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/file_size"
         },
-        "file_path": {
+        "ClientSideOriginalFilepath": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/file_path"
         }
       },
       "required": [
         "UUID",
-        "date_last_modified",
-        "client_side_checksum",
-        "file_size",
-        "file_path"
+        "ClientSideFileLastModifiedDate",
+        "SHA256ClientSideChecksum",
+        "ClientSideFileSize",
+        "ClientSideOriginalFilepath"
       ]
     }
   ]

--- a/src/test/resources/data/sharepointDataLoad.json
+++ b/src/test/resources/data/sharepointDataLoad.json
@@ -1,7 +1,7 @@
 {
-  "date_last_modified": "2001-12-12",
-  "client_side_checksum": "8b9118183f01b3df0fc5073feb68f0ecd5a7f85a88ed63ac7d0d242dc2aba2ea",
-  "file_size": 26,
-  "file_path": "a/filepath/filename1.docx",
+  "ClientSideFileLastModifiedDate": "2001-12-12",
+  "SHA256ClientSideChecksum": "8b9118183f01b3df0fc5073feb68f0ecd5a7f85a88ed63ac7d0d242dc2aba2ea",
+  "ClientSideFileSize": 26,
+  "ClientSideOriginalFilepath": "a/filepath/filename1.docx",
   "UUID": "b8b624e4-ec68-4e08-b5db-dfdc9ec84fea"
 }

--- a/src/test/resources/data/sharepointDataLoadInvalidFilePath.json
+++ b/src/test/resources/data/sharepointDataLoadInvalidFilePath.json
@@ -1,7 +1,7 @@
 {
-  "date_last_modified": "2001-12-12",
-  "client_side_checksum": "8b9118183f01b3df0fc5073feb68f0ecd5a7f85a88ed63ac7d0d242dc2aba2ea",
-  "file_size": 26,
-  "file_path": "",
+  "ClientSideFileLastModifiedDate": "2001-12-12",
+  "SHA256ClientSideChecksum": "8b9118183f01b3df0fc5073feb68f0ecd5a7f85a88ed63ac7d0d242dc2aba2ea",
+  "ClientSideFileSize": 26,
+  "ClientSideOriginalFilepath": "",
   "UUID": "b8b624e4-ec68-4e08-b5db-dfdc9ec84fea"
 }

--- a/src/test/resources/data/sharepointDataLoadInvalidFileSize.json
+++ b/src/test/resources/data/sharepointDataLoadInvalidFileSize.json
@@ -1,7 +1,7 @@
 {
-  "date_last_modified": "2001-12-12",
-  "client_side_checksum": "8b9118183f01b3df0fc5073feb68f0ecd5a7f85a88ed63ac7d0d242dc2aba2ea",
-  "file_size": -26,
-  "file_path": "a/filepath/filename1.docx",
+  "ClientSideFileLastModifiedDate": "2001-12-12",
+  "SHA256ClientSideChecksum": "8b9118183f01b3df0fc5073feb68f0ecd5a7f85a88ed63ac7d0d242dc2aba2ea",
+  "ClientSideFileSize": -26,
+  "ClientSideOriginalFilepath": "a/filepath/filename1.docx",
   "UUID": "b8b624e4-ec68-4e08-b5db-dfdc9ec84fea"
 }

--- a/src/test/resources/data/sharepointDataLoadMissingProperty.json
+++ b/src/test/resources/data/sharepointDataLoadMissingProperty.json
@@ -1,6 +1,6 @@
 {  
-  "client_side_checksum": "8b9118183f01b3df0fc5073feb68f0ecd5a7f85a88ed63ac7d0d242dc2aba2ea",
-  "file_size": 26,
-  "file_path": "a/filepath/filename1.docx",
+  "SHA256ClientSideChecksum": "8b9118183f01b3df0fc5073feb68f0ecd5a7f85a88ed63ac7d0d242dc2aba2ea",
+  "ClientSideFileSize": 26,
+  "ClientSideOriginalFilepath": "a/filepath/filename1.docx",
   "UUID": "b8b624e4-ec68-4e08-b5db-dfdc9ec84fea"  
 }

--- a/src/test/resources/metadata-schema/baseSchema.schema.json
+++ b/src/test/resources/metadata-schema/baseSchema.schema.json
@@ -4,12 +4,24 @@
   "properties": {
     "client_side_checksum": {
       "type": "string",
-      "propertyType": "System"
+      "propertyType": "System",
+      "minLength": 64,
+      "maximum": 64,
+      "alternateKeys": [
+        {
+          "tdrDataLoadHeader": "SHA256ClientSideChecksum"
+        }
+      ]
     },
     "file_size": {
       "propertyType": "System",
-      "type": "number",
-      "minimum": 0
+      "type": "integer",
+      "minimum": 0,
+      "alternateKeys": [
+        {
+          "tdrDataLoadHeader": "ClientSideFileSize"
+        }
+      ]
     },
     "UUID": {
       "type": "string",
@@ -27,7 +39,8 @@
       "minLength": 1,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Filepath"
+          "tdrFileHeader": "Filepath",
+          "tdrDataLoadHeader": "ClientSideOriginalFilepath"
         }
       ]
     },
@@ -37,7 +50,8 @@
       "propertyType": "System",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Date last modified"
+          "tdrFileHeader": "Date last modified",
+          "tdrDataLoadHeader": "ClientSideFileLastModifiedDate"
         }
       ]
     },
@@ -84,7 +98,8 @@
       "minLength": 1,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Filename"
+          "tdrFileHeader": "Filename",
+          "tdrDataLoadHeader": "Filename"
         }
       ]
     },
@@ -113,7 +128,8 @@
       "maxLength": 8000,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Alternative description"
+          "tdrFileHeader": "Alternative description",
+          "tdrDataLoadHeader": "DescriptionAlternate"
         }
       ]
     },
@@ -125,7 +141,8 @@
       "propertyType": "Supplied",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Is the description sensitive for the public?"
+          "tdrFileHeader": "Is the description sensitive for the public?",
+          "tdrDataLoadHeader": "DescriptionClosed"
         }
       ]
     },
@@ -138,7 +155,8 @@
       "propertyType": "Supplied",
       "alternateKeys": [
         {
-          "tdrFileHeader": "FOI decision asserted"
+          "tdrFileHeader": "FOI decision asserted",
+          "tdrDataLoadHeader": "FoiExemptionAsserted"
         }
       ],
       "daBeforeToday": "Validates that FOI Exemption Asserted Date is before today's date"
@@ -155,7 +173,8 @@
       },
       "alternateKeys": [
         {
-          "tdrFileHeader": "FOI exemption code"
+          "tdrFileHeader": "FOI exemption code",
+          "tdrDataLoadHeader": "FoiExemptionCode"
         }
       ]
     },
@@ -165,7 +184,8 @@
       "$ref": "classpath:/metadata-schema/definitionsSchema.schema.json#/definitions/closure_types",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Closure status"
+          "tdrFileHeader": "Closure status",
+          "tdrDataLoadHeader": "ClosureType"
         }
       ]
     },
@@ -179,7 +199,8 @@
       "maximum": 150,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Closure Period"
+          "tdrFileHeader": "Closure Period",
+          "tdrDataLoadHeader": "ClosurePeriod"
         }
       ]
     },
@@ -192,7 +213,8 @@
       "propertyType": "Supplied",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Closure Start Date"
+          "tdrFileHeader": "Closure Start Date",
+          "tdrDataLoadHeader": "ClosureStartDate"
         }
       ]
     },
@@ -204,7 +226,8 @@
       "propertyType": "Supplied",
       "alternateKeys": [
         {
-          "tdrFileHeader": "Is the title sensitive for the public?"
+          "tdrFileHeader": "Is the title sensitive for the public?",
+          "tdrDataLoadHeader": "ClosureType"
         }
       ]
     },
@@ -217,7 +240,8 @@
       "maxLength": 8000,
       "alternateKeys": [
         {
-          "tdrFileHeader": "Add alternative title without the file extension"
+          "tdrFileHeader": "Add alternative title without the file extension",
+          "tdrDataLoadHeader": "TitleAlternate"
         }
       ]
     },

--- a/src/test/resources/metadata-schema/dataLoadSharePointSchema.schema.json
+++ b/src/test/resources/metadata-schema/dataLoadSharePointSchema.schema.json
@@ -7,27 +7,26 @@
         "UUID": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/UUID"
         },
-        "date_last_modified": {
+        "ClientSideFileLastModifiedDate": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/date_last_modified"
         },
-        "client_side_checksum": {
+        "SHA256ClientSideChecksum": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/client_side_checksum"
         },
-        "file_size": {
+        "ClientSideFileSize": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/file_size"
         },
-        "file_path": {
+        "ClientSideOriginalFilepath": {
           "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/file_path"
         }
       },
       "required": [
         "UUID",
-        "date_last_modified",
-        "client_side_checksum",
-        "file_size",
-        "file_path"
+        "ClientSideFileLastModifiedDate",
+        "SHA256ClientSideChecksum",
+        "ClientSideFileSize",
+        "ClientSideOriginalFilepath"
       ]
     }
   ]
 }
-

--- a/src/test/scala/uk/gov/tna/metadata/schema/validator/SharepointDataLoadSchemaSpec.scala
+++ b/src/test/scala/uk/gov/tna/metadata/schema/validator/SharepointDataLoadSchemaSpec.scala
@@ -28,10 +28,10 @@ class SharepointDataLoadSchemaSpec extends BaseSpec {
 
       errors.size() shouldBe 1
       val errorsArray = errors.asScala.toArray
-      errorsArray(0).getMessage shouldBe "$: required property 'date_last_modified' not found"
+      errorsArray(0).getMessage shouldBe "$: required property 'ClientSideFileLastModifiedDate' not found"
     }
 
-    "fail when 'file_size' is less than 0" in {
+    "fail when 'ClientSideFileSize' is less than 0" in {
       val testDataPath = "/data/sharepointDataLoadInvalidFileSize.json"
       val schemaSetup = createSchema(schemaPath, testDataPath)
 
@@ -39,10 +39,10 @@ class SharepointDataLoadSchemaSpec extends BaseSpec {
 
       errors.size() shouldBe 1
       val errorsArray = errors.asScala.toArray
-      errorsArray(0).getMessage shouldBe "$.file_size: must have a minimum value of 0"
+      errorsArray(0).getMessage shouldBe "$.ClientSideFileSize: must have a minimum value of 0"
     }
 
-    "fail when 'file_path' is less than 1" in {
+    "fail when 'ClientSideOriginalFilepath' is less than 1" in {
 
       val testDataPath = "/data/sharepointDataLoadInvalidFilePath.json"
       val schemaSetup = createSchema(schemaPath, testDataPath)
@@ -51,7 +51,7 @@ class SharepointDataLoadSchemaSpec extends BaseSpec {
 
       errors.size() shouldBe 1
       val errorsArray = errors.asScala.toArray
-      errorsArray(0).getMessage shouldBe "$.file_path: must be at least 1 characters long"
+      errorsArray(0).getMessage shouldBe "$.ClientSideOriginalFilepath: must be at least 1 characters long"
     }
   }
 }


### PR DESCRIPTION
Data load properties will be generally coming directly from a service, eg SharePoint, DROID and will not be in a TDR readable form

Provide alternative headers for data load to allow header to be converted correctly for validation

These new alternative headers ('tdrDataLoadHeader') correspond to the property names used to store the data in the TDR database where that differs from the property name in the Base Schema

Rename data load alternative header to make TDR specific