### PR TITLE
Additional properties used in the Bagit Export

### DIFF
--- a/metadata-schema/baseSchema.schema.json
+++ b/metadata-schema/baseSchema.schema.json
@@ -144,6 +144,42 @@
       ],
       "maxLength": 255,
       "pattern": "^[^\\r\\n]*$"
+    },
+    "file_reference": {
+      "description": "Human readable reference for the file",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "file_type": {
+      "description": "Whether type is a file or folder",
+      "type": "string",
+      "$ref": "classpath:/metadata-schema/definitionsSchema.schema.json#/definitions/file_types"
+    },
+    "parent_reference": {
+      "description": "Human readable reference for the file's parent folder",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "original_identifier": {
+      "description": "The original filepath of a redacted file",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "legal_status": {
+      "description": "The legal status of the file",
+      "type": "string",
+      "$ref": "classpath:/metadata-schema/definitionsSchema.schema.json#/definitions/legal_statuses"
+    },
+    "held_by": {
+      "description": "Who holds the digital copy",
+      "type": "string",
+      "$ref": "classpath:/metadata-schema/definitionsSchema.schema.json#/definitions/held_by"
     }
   }
 }

--- a/metadata-schema/definitionsSchema.schema.json
+++ b/metadata-schema/definitionsSchema.schema.json
@@ -56,6 +56,24 @@
         "English",
         "Welsh"
       ]
+    },
+    "file_types": {
+      "enum": [
+        "File",
+        "Folder"
+      ]
+    },
+    "legal_statuses": {
+      "enum": [
+        "Public Record(s)",
+        "Not Public Record(s)",
+        "Welsh Public Record(s)"
+      ]
+    },
+    "held_by": {
+      "enum": [
+        "The National Archives, Kew"
+      ]
     }
   }
 }


### PR DESCRIPTION
Properties outputted to the `file-metadata.csv' in the export

Needed to generate display configuration for the Bagit Export

Values copied from those currently held in the DB

Can be amended if required later