### PR TITLE
Tdrd 868 property to default value

### DIFF
--- a/config-schema/config.json
+++ b/config-schema/config.json
@@ -709,6 +709,7 @@
       "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/legal_status",
       "propertyType": "Supplied",
       "expectedTDRHeader": false,
+      "defaultValue": "Public Record(s)",
       "allowExport": true,
       "alternateKeys": [
         {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtils.scala
@@ -182,6 +182,14 @@ object ConfigUtils {
     key => defaultValueMap.getOrElse(key, "")
   }
 
+  /** Retrieves a map of properties to default values
+   *
+   * @param configurationParameters
+   *   The configuration parameters containing the config data.
+   * @return
+   *   mapping of between all properties with a default value and the default value itself
+   * 
+   */
   private def getPropertiesToDefaultValueMap(configurationParameters: ConfigParameters): Map[String, String] = {
     configurationParameters.baseConfig
       .getOrElse(Config(List.empty[ConfigItem]))

--- a/src/main/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtils.scala
@@ -12,6 +12,8 @@ import scala.util.Using
 
 object ConfigUtils {
 
+  val ARRAY_SPLIT_CHAR = ";"
+
   private val BASE_SCHEMA: String = "/metadata-schema/baseSchema.schema.json"
   private val CONFIG_SCHEMA: String = "config-schema/config.json"
 
@@ -188,7 +190,7 @@ object ConfigUtils {
    *   The configuration parameters containing the config data.
    * @return
    *   mapping of between all properties with a default value and the default value itself
-   * 
+   *
    */
   private def getPropertiesToDefaultValueMap(configurationParameters: ConfigParameters): Map[String, String] = {
     configurationParameters.baseConfig

--- a/src/test/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtilsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtilsSpec.scala
@@ -40,6 +40,12 @@ class ConfigUtilsSpec extends AnyWordSpec {
     }
   }
 
+  "ConfigUtils" should {
+    "return semi-colon as 'ARRAY_SPLIT_CHAR'" in {
+      ConfigUtils.ARRAY_SPLIT_CHAR shouldBe ";"
+    }
+  }
+
   "ConfigUtils should load configuration and provide an inputToPropertyMapper method that" should {
     "give the base Schema property for a domain key" in {
       val metadataConfiguration = ConfigUtils.loadConfiguration
@@ -156,13 +162,14 @@ class ConfigUtilsSpec extends AnyWordSpec {
 
   "ConfigUtils should load configuration and provide a getPropertiesWithDefaultValue method that" should {
     "return a mapping of properties with a default value set" in {
-      val expectedPropertiesWithDefaultValue = List("closure_type", "language", "description_closed", "title_closed", "rights_copyright", "held_by")
+      val expectedPropertiesWithDefaultValue = List("closure_type", "language", "legal_status", "description_closed", "title_closed", "rights_copyright", "held_by")
       val metadataConfiguration = ConfigUtils.loadConfiguration
       val mapping = metadataConfiguration.getPropertiesWithDefaultValue
-      mapping.size shouldBe 6
+      mapping.size shouldBe 7
       mapping.keys.toList shouldBe expectedPropertiesWithDefaultValue
       mapping("closure_type") shouldBe "Open"
       mapping("language") shouldBe "English"
+      mapping("legal_status") shouldBe "Public Record(s)"
       mapping("description_closed") shouldBe "false"
       mapping("title_closed") shouldBe "false"
       mapping("rights_copyright") shouldBe "Crown copyright"

--- a/src/test/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtilsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtilsSpec.scala
@@ -154,4 +154,19 @@ class ConfigUtilsSpec extends AnyWordSpec {
     }
   }
 
+  "ConfigUtils should load configuration and provide a getPropertiesWithDefaultValue method that" should {
+    "return a mapping of properties with a default value set" in {
+      val expectedPropertiesWithDefaultValue = List("closure_type", "language", "description_closed", "title_closed", "rights_copyright", "held_by")
+      val metadataConfiguration = ConfigUtils.loadConfiguration
+      val mapping = metadataConfiguration.getPropertiesWithDefaultValue
+      mapping.size shouldBe 6
+      mapping.keys.toList shouldBe expectedPropertiesWithDefaultValue
+      mapping("closure_type") shouldBe "Open"
+      mapping("language") shouldBe "English"
+      mapping("description_closed") shouldBe "false"
+      mapping("title_closed") shouldBe "false"
+      mapping("rights_copyright") shouldBe "Crown copyright"
+      mapping("held_by") shouldBe "The National Archives, Kew"
+    }
+  }
 }


### PR DESCRIPTION
Support for initial creation of file entries in DB

Default values are added to metadata when files entries initially created in the DB

Revert `ARRAY_SPLIT_CHAR` removal. Broke clients using the config json. Added unit test so clear this value is required by clients