### PR TITLE
TDRD-1456 Update disallowed puids

### DIFF
--- a/puids/disallowed-puids.json
+++ b/puids/disallowed-puids.json
@@ -114,12 +114,6 @@
     "puidDescription": "Raw Flux Image"
   },
   {
-    "puid": "fmt/1281",
-    "active": true,
-    "reason": "Zip",
-    "puidDescription": "WARC 1.1"
-  },
-  {
     "puid": "fmt/1340",
     "active": true,
     "reason": "Zip",
@@ -130,12 +124,6 @@
     "active": true,
     "reason": "Zip",
     "puidDescription": "ASICS"
-  },
-  {
-    "puid": "fmt/1355",
-    "active": true,
-    "reason": "Zip",
-    "puidDescription": "WARC 1.0"
   },
   {
     "puid": "fmt/1361",
@@ -176,7 +164,7 @@
   {
     "puid": "fmt/473",
     "active": true,
-    "reason": "OperatingSystemMac",
+    "reason": "NonRecord",
     "puidDescription": "Microsoft Office Owner File"
   },
   {
@@ -428,7 +416,7 @@
   {
     "puid": "x-fmt/45",
     "active": true,
-    "reason": "Template",
+    "reason": "NonRecord",
     "puidDescription": "Microsoft Word Document Template"
   },
   {


### PR DESCRIPTION
Remove the following PUIDs from the disallowed list:

- fmt/1281 (WARC 1.1)
- fmt/1355 (WARC 1.0)

Update ‘Reason’ as follows for these PUIDs

- x-fmt/45: NonRecord
- fmt/473: NonRecord