### PR TITLE
Alter schema and config to include 'Asset Id' property

### DIFF
--- a/config-schema/config.json
+++ b/config-schema/config.json
@@ -1166,6 +1166,15 @@
           "editable": false
         }
       ]
+    },
+    {
+      "key": "asset_id",
+      "$ref": "classpath:/metadata-schema/baseSchema.schema.json#/properties/asset_id",
+      "propertyType": "System",
+      "expectedTDRHeader": false,
+      "allowExport": false,
+      "alternateKeys": [],
+      "downloadFilesOutputs": []
     }
   ]
 }

--- a/config-schema/config.json
+++ b/config-schema/config.json
@@ -1173,7 +1173,11 @@
       "propertyType": "System",
       "expectedTDRHeader": false,
       "allowExport": false,
-      "alternateKeys": [],
+      "alternateKeys": [
+        {
+          "tdrDataLoadHeader": "AssetId"
+        }
+      ],
       "downloadFilesOutputs": []
     }
   ]

--- a/metadata-schema/baseSchema.schema.json
+++ b/metadata-schema/baseSchema.schema.json
@@ -344,6 +344,11 @@
       ],
       "maxLength": 255,
       "pattern": "^[^\\r\\n]*$"
+    },
+    "asset_id": {
+      "description": "Asset id for the record",
+      "type": "string",
+      "format": "uuid"
     }
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtilsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/schemautils/ConfigUtilsSpec.scala
@@ -21,7 +21,7 @@ class ConfigUtilsSpec extends AnyWordSpec {
       .getOrElse(Config(List.empty[ConfigItem])).configItems.map(_.key)
 
     "contain the correct number of properties" in {
-      propertyKeys.size should equal(46)
+      propertyKeys.size should equal(47)
     }
 
     "not contain duplicate properties" in {
@@ -95,7 +95,7 @@ class ConfigUtilsSpec extends AnyWordSpec {
       val metadataConfiguration = ConfigUtils.loadConfiguration
       metadataConfiguration.getPropertiesByPropertyType("System") shouldBe
         List("file_path", "file_name", "date_last_modified", "file_size", "UUID", "file_reference",
-          "original_identifier", "parent_reference", "file_type", "client_side_checksum", "server_side_checksum")
+          "original_identifier", "parent_reference", "file_type", "client_side_checksum", "server_side_checksum", "asset_id")
       metadataConfiguration.getPropertiesByPropertyType("Supplied") shouldBe
         List("end_date", "description", "former_reference_department", "closure_type", "closure_start_date", "closure_period",
           "foi_exemption_code", "foi_exemption_asserted", "title_closed", "description_closed", "description_alternate", "title_alternate",


### PR DESCRIPTION
TDR needs to generate and persist the 'asset id' to ensure idempotency for DR2 systems